### PR TITLE
Build and doc refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 activemq-data
 *.epoch
 *.log
+.yardoc

--- a/README.adoc
+++ b/README.adoc
@@ -8,4 +8,7 @@ Please see the in source asciidoc documentation or the main documentation on the
 of this component:
 
 * Web-site docs
-* link:src/main/asciidoc/index.adoc[in-source docs]
+* link:src/main/asciidoc/groovy/index.adoc[Groovy in-source docs]
+* link:src/main/asciidoc/java/index.adoc[Java in-source docs]
+* link:src/main/asciidoc/js/index.adoc[JS in-source docs]
+* link:src/main/asciidoc/ruby/index.adoc[Ruby in-source docs]

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 
   <parent>
     <groupId>io.vertx</groupId>
-    <artifactId>vertx-parent</artifactId>
-    <version>5</version>
+    <artifactId>vertx-ext-parent</artifactId>
+    <version>16</version>
   </parent>
 
   <artifactId>vertx-jgroups</artifactId>
@@ -52,13 +52,38 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-groovy</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-ruby</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-js</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codetrans</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -79,44 +104,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>default-compile</id>
-              <configuration>
-                <annotationProcessors>
-                  <annotationProcessor>io.vertx.docgen.JavaDocGenProcessor</annotationProcessor>
-                </annotationProcessors>
-                <compilerArgs>
-                  <arg>-Adocgen.output=${asciidoc.dir}</arg>
-                </compilerArgs>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.asciidoctor</groupId>
-          <artifactId>asciidoctor-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <goals>
-                <goal>process-asciidoc</goal>
-              </goals>
-              <configuration>
-                <sourceDirectory>${asciidoc.dir}</sourceDirectory>
-                <outputDirectory>${project.build.directory}/docs/${project.artifactId}</outputDirectory>
-                <sourceHighlighter>coderay</sourceHighlighter>
-                <preserveDirectories>true</preserveDirectories>
-                <relativeBaseDir>true</relativeBaseDir>
-                <backend>html</backend>
-                <doctype>book</doctype>
-              </configuration>
-              <phase>prepare-package</phase>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.plugin.version}</version>
@@ -132,25 +119,6 @@
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>package-docs</id>
-              <phase>prepare-package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
-              <configuration>
-                <attach>true</attach>
-                <descriptors>
-                  <descriptor>${basedir}/src/main/assembly/docs.xml</descriptor>
-                </descriptors>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -1,0 +1,190 @@
+= JGroups Cluster Manager
+
+This is a cluster manager implementation for Vert.x that uses http://www.jgroups.org[JGroups].
+
+In Vert.x a cluster manager is used for various functions including:
+
+* Discovery and group membership of Vert.x nodes in a cluster
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+addresses)
+* Distributed Map support
+* Distributed Locks
+* Distributed Counters
+
+Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
+
+== Using this cluster manager
+
+To use the the cluster manager, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>{maven-groupId}</groupId>
+  <artifactId>{maven-artifactId}</artifactId>
+  <version>{maven-version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile {maven-groupId}:{maven-artifactId}:{maven-version}
+----
+
+
+If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
+`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+
+If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
+Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+
+You can also specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options
+when you are creating your Vert.x instance, for example:
+
+[source,groovy]
+----
+import io.vertx.groovy.core.Vertx
+def mgr = new io.vertx.java.spi.cluster.impl.jgroups.JGroupsClusterManager()
+def options = [
+  clusterManager:mgr
+]
+Vertx.clusteredVertx(options, { res ->
+  if (res.succeeded()) {
+    def vertx = res.result()
+  } else {
+    // failed!
+  }
+})
+
+----
+
+== Configuring this cluster manager
+
+Usually the cluster manager is configured by a file:
+
+.default-jgroups.xml
+[source,xml]
+----
+include::../../resources/default-jgroups.xml[]
+----
+
+This file is packaged in the JGroup cluster Manager jar file.
+
+If you want to override this configuration you can provide a file called `jgroups.xml` on your classpath and this
+will be used instead.
+
+The xml file is a JGroups configuration file and is described in detail in the documentation on the JGroups
+web-site.
+
+JGroups supports several different transports including multicast and TCP. The default configuration uses
+multicast so you must have multicast enabled on your network for this to work.
+
+For full documentation on how to configure the transport differently or use a different transport please consult the
+JGroups documentation.
+
+== Trouble shooting clustering
+
+If the default multicast configuration is not working here are some common causes:
+
+=== Multicast not enabled on the machine.
+
+When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
+the routing table otherwise, the default route will be used
+
+Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+
+MacOS example:
+
+----
+# Adds a multicast route for 224.0.0.1-231.255.255.254
+sudo route add -net 224.0.0.0/5 127.0.0.1
+
+# Adds a multicast route for 232.0.0.1-239.255.255.254
+sudo route add -net 232.0.0.0/5 192.168.1.3
+----
+
+Please google for more information.
+
+
+=== Using IPv6 without a correctly configured routing table
+
+Running in IPv6 without a correctly configured IPv6 routing table
+
+By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
+Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`). More details about this
+are available on https://developer.jboss.org/wiki/IPv6.
+
+
+=== Using wrong network interface
+
+If you have more than one network interface on your machine (and this can also be the case if you are running
+VPN software on your machine), then JGroups may be using the wrong one.
+
+Java parameter `jgroups.bind_addr` determines the network interface to bind to, e.g. `jgroups.bind_addr=192.168.1.5`.
+
+The following values are also recognized:
+
+* `global`: picks a global IP address if available. If not, falls back to a `site-local` IP address
+* `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address
+range.
+* `link_local`: picks a link-local IP address, from +169.254.1.0+ through +169.254.254.255+.
+* `non_loopback`: picks _any_ non loopback address.
+* `loopback`: picks a loopback address, e.g. +127.0.0.1+.
+* `match-interface`: picks an address which matches a pattern against the interface name,
+e.g. +match-interface:eth.\*+
+* `match-host`: picks an address which matches a pattern against the host name,
+e.g. +match-host:linux.\*+
+* `match-address`: picks an address which matches a pattern against the host address,
+e.g. +match-address:192.168.\*+
+
+When running Vert.x is in clustered mode, you should also make sure that Vert.x knows about the correct interface.
+When running at the command line this is done by specifying the `cluster-host` option:
+
+----
+vertx run myverticle.js -cluster -cluster-host your-ip-address
+----
+
+Where `your-ip-address` is the same IP address you specified in the JGroups configuration.
+
+If using Vert.x programmatically you can specify this using `link:../../apidocs/io/vertx/core/VertxOptions.html#setClusterHost-java.lang.String-[setClusterHost]`.
+
+
+=== Using a VPN
+
+This is a variation of the above case. VPN software often works by creating a virtual network interface which often
+doesn't support multicast. If you have a VPN running and you do not specify the correct interface to use in both the
+jgroups configuration and to Vert.x then the VPN interface may be chosen instead of the correct interface.
+
+So, if you have a VPN running you may have to configure both the JGroups and Vert.x to use the correct interface as
+described in the previous section.
+
+=== When multicast is not available
+
+In some cases you may not be able to use multicast as it might not be available in your environment. In that case
+you should configure another transport, e.g. TCP  to use TCP sockets, or AWS when running on Amazon EC2.
+
+For more information on available JGroups transports and how to configure them please consult the JGroups
+documentation.
+
+=== Enabling logging
+
+When trouble-shooting clustering issues with JGroups it's often useful to get some logging output from JGroups
+to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+configuration file. Inside it set:
+
+----
+org.jgroups.level=INFO
+----
+
+and also
+
+----
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.FileHandler.level=INFO
+----

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -38,7 +38,7 @@ compile {maven-groupId}:{maven-artifactId}:{maven-version}
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-jgroups-{maven-version}.jar` should be in the `lib` directory of the Vert.x installation.
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
 Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -38,7 +38,7 @@ compile {maven-groupId}:{maven-artifactId}:{maven-version}
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-jgroups-{maven-version}.jar` should be in the `lib` directory of the Vert.x installation.
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
 Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -5,7 +5,8 @@ This is a cluster manager implementation for Vert.x that uses http://www.jgroups
 In Vert.x a cluster manager is used for various functions including:
 
 * Discovery and group membership of Vert.x nodes in a cluster
-* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus addresses)
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+addresses)
 * Distributed Map support
 * Distributed Locks
 * Distributed Counters
@@ -14,11 +15,30 @@ Cluster managers *do not* handle the event bus inter-node transport, this is don
 
 == Using this cluster manager
 
-If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named `vertx-jgroups-${version}`.jar`
-should be in the `lib` directory of the Vert.x installation.
+To use the the cluster manager, add the following dependency to the _dependencies_ section of your build
+descriptor:
 
-If you want clustering with this cluster manager in your Vert.x Maven or Gradle project then just add a dependency to
-the artifact: `io.vertx:vertx-jgroups:${version}` in your project.
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>{maven-groupId}</groupId>
+  <artifactId>{maven-artifactId}</artifactId>
+  <version>{maven-version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile {maven-groupId}:{maven-artifactId}:{maven-version}
+----
+
+
+If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
+`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
 Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.
@@ -29,9 +49,7 @@ when you are creating your Vert.x instance, for example:
 [source,java]
 ----
 ClusterManager mgr = new JGroupsClusterManager();
-
 VertxOptions options = new VertxOptions().setClusterManager(mgr);
-
 Vertx.clusteredVertx(options, res -> {
   if (res.succeeded()) {
     Vertx vertx = res.result();
@@ -43,9 +61,15 @@ Vertx.clusteredVertx(options, res -> {
 
 == Configuring this cluster manager
 
-Usually the cluster manager is configured by a file
-https://github.com/vert-x3/vertx-jgroups/blob/master/src/main/resources/default-jgroups.xml[`default-jgroups.xml`]
-which is packaged inside the jar.
+Usually the cluster manager is configured by a file:
+
+.default-jgroups.xml
+[source,xml]
+----
+include::../../resources/default-jgroups.xml[]
+----
+
+This file is packaged in the JGroup cluster Manager jar file.
 
 If you want to override this configuration you can provide a file called `jgroups.xml` on your classpath and this
 will be used instead.
@@ -68,7 +92,7 @@ If the default multicast configuration is not working here are some common cause
 When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
 the routing table otherwise, the default route will be used
 
-* Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
 
 MacOS example:
 
@@ -87,10 +111,9 @@ Please google for more information.
 
 Running in IPv6 without a correctly configured IPv6 routing table
 
-* By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
-* Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`)
-
-Wiki: https://developer.jboss.org/wiki/IPv6
+By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
+Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`). More details about this
+are available on https://developer.jboss.org/wiki/IPv6.
 
 
 === Using wrong network interface
@@ -103,16 +126,17 @@ Java parameter `jgroups.bind_addr` determines the network interface to bind to, 
 The following values are also recognized:
 
 * `global`: picks a global IP address if available. If not, falls back to a `site-local` IP address
-* `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address range.
+* `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address
+range.
 * `link_local`: picks a link-local IP address, from +169.254.1.0+ through +169.254.254.255+.
 * `non_loopback`: picks _any_ non loopback address.
 * `loopback`: picks a loopback address, e.g. +127.0.0.1+.
 * `match-interface`: picks an address which matches a pattern against the interface name,
-                  e.g. +match-interface:eth.\*+
+e.g. +match-interface:eth.\*+
 * `match-host`: picks an address which matches a pattern against the host name,
-             e.g. +match-host:linux.\*+
+e.g. +match-host:linux.\*+
 * `match-address`: picks an address which matches a pattern against the host address,
-                e.g. +match-address:192.168.\*+
+e.g. +match-address:192.168.\*+
 
 When running Vert.x is in clustered mode, you should also make sure that Vert.x knows about the correct interface.
 When running at the command line this is done by specifying the `cluster-host` option:

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -1,0 +1,190 @@
+= JGroups Cluster Manager
+
+This is a cluster manager implementation for Vert.x that uses http://www.jgroups.org[JGroups].
+
+In Vert.x a cluster manager is used for various functions including:
+
+* Discovery and group membership of Vert.x nodes in a cluster
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+addresses)
+* Distributed Map support
+* Distributed Locks
+* Distributed Counters
+
+Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
+
+== Using this cluster manager
+
+To use the the cluster manager, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>{maven-groupId}</groupId>
+  <artifactId>{maven-artifactId}</artifactId>
+  <version>{maven-version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile {maven-groupId}:{maven-artifactId}:{maven-version}
+----
+
+
+If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
+`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+
+If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
+Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+
+You can also specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options
+when you are creating your Vert.x instance, for example:
+
+[source,js]
+----
+var Vertx = require("vertx-js/vertx");
+var mgr = new (Java.type("io.vertx.java.spi.cluster.impl.jgroups.JGroupsClusterManager"))();
+var options = {
+  "clusterManager" : mgr
+};
+Vertx.clusteredVertx(options, function (res, res_err) {
+  if (res_err == null) {
+    var vertx = res;
+  } else {
+    // failed!
+  }
+});
+
+----
+
+== Configuring this cluster manager
+
+Usually the cluster manager is configured by a file:
+
+.default-jgroups.xml
+[source,xml]
+----
+include::../../resources/default-jgroups.xml[]
+----
+
+This file is packaged in the JGroup cluster Manager jar file.
+
+If you want to override this configuration you can provide a file called `jgroups.xml` on your classpath and this
+will be used instead.
+
+The xml file is a JGroups configuration file and is described in detail in the documentation on the JGroups
+web-site.
+
+JGroups supports several different transports including multicast and TCP. The default configuration uses
+multicast so you must have multicast enabled on your network for this to work.
+
+For full documentation on how to configure the transport differently or use a different transport please consult the
+JGroups documentation.
+
+== Trouble shooting clustering
+
+If the default multicast configuration is not working here are some common causes:
+
+=== Multicast not enabled on the machine.
+
+When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
+the routing table otherwise, the default route will be used
+
+Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+
+MacOS example:
+
+----
+# Adds a multicast route for 224.0.0.1-231.255.255.254
+sudo route add -net 224.0.0.0/5 127.0.0.1
+
+# Adds a multicast route for 232.0.0.1-239.255.255.254
+sudo route add -net 232.0.0.0/5 192.168.1.3
+----
+
+Please google for more information.
+
+
+=== Using IPv6 without a correctly configured routing table
+
+Running in IPv6 without a correctly configured IPv6 routing table
+
+By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
+Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`). More details about this
+are available on https://developer.jboss.org/wiki/IPv6.
+
+
+=== Using wrong network interface
+
+If you have more than one network interface on your machine (and this can also be the case if you are running
+VPN software on your machine), then JGroups may be using the wrong one.
+
+Java parameter `jgroups.bind_addr` determines the network interface to bind to, e.g. `jgroups.bind_addr=192.168.1.5`.
+
+The following values are also recognized:
+
+* `global`: picks a global IP address if available. If not, falls back to a `site-local` IP address
+* `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address
+range.
+* `link_local`: picks a link-local IP address, from +169.254.1.0+ through +169.254.254.255+.
+* `non_loopback`: picks _any_ non loopback address.
+* `loopback`: picks a loopback address, e.g. +127.0.0.1+.
+* `match-interface`: picks an address which matches a pattern against the interface name,
+e.g. +match-interface:eth.\*+
+* `match-host`: picks an address which matches a pattern against the host name,
+e.g. +match-host:linux.\*+
+* `match-address`: picks an address which matches a pattern against the host address,
+e.g. +match-address:192.168.\*+
+
+When running Vert.x is in clustered mode, you should also make sure that Vert.x knows about the correct interface.
+When running at the command line this is done by specifying the `cluster-host` option:
+
+----
+vertx run myverticle.js -cluster -cluster-host your-ip-address
+----
+
+Where `your-ip-address` is the same IP address you specified in the JGroups configuration.
+
+If using Vert.x programmatically you can specify this using `link:../../apidocs/io/vertx/core/VertxOptions.html#setClusterHost-java.lang.String-[setClusterHost]`.
+
+
+=== Using a VPN
+
+This is a variation of the above case. VPN software often works by creating a virtual network interface which often
+doesn't support multicast. If you have a VPN running and you do not specify the correct interface to use in both the
+jgroups configuration and to Vert.x then the VPN interface may be chosen instead of the correct interface.
+
+So, if you have a VPN running you may have to configure both the JGroups and Vert.x to use the correct interface as
+described in the previous section.
+
+=== When multicast is not available
+
+In some cases you may not be able to use multicast as it might not be available in your environment. In that case
+you should configure another transport, e.g. TCP  to use TCP sockets, or AWS when running on Amazon EC2.
+
+For more information on available JGroups transports and how to configure them please consult the JGroups
+documentation.
+
+=== Enabling logging
+
+When trouble-shooting clustering issues with JGroups it's often useful to get some logging output from JGroups
+to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+configuration file. Inside it set:
+
+----
+org.jgroups.level=INFO
+----
+
+and also
+
+----
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.FileHandler.level=INFO
+----

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -38,7 +38,7 @@ compile {maven-groupId}:{maven-artifactId}:{maven-version}
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-jgroups-{maven-version}.jar` should be in the `lib` directory of the Vert.x installation.
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
 Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -38,7 +38,7 @@ compile {maven-groupId}:{maven-artifactId}:{maven-version}
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-jgroups-{maven-version}.jar` should be in the `lib` directory of the Vert.x installation.
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
 Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -1,0 +1,190 @@
+= JGroups Cluster Manager
+
+This is a cluster manager implementation for Vert.x that uses http://www.jgroups.org[JGroups].
+
+In Vert.x a cluster manager is used for various functions including:
+
+* Discovery and group membership of Vert.x nodes in a cluster
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+addresses)
+* Distributed Map support
+* Distributed Locks
+* Distributed Counters
+
+Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
+
+== Using this cluster manager
+
+To use the the cluster manager, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>{maven-groupId}</groupId>
+  <artifactId>{maven-artifactId}</artifactId>
+  <version>{maven-version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile {maven-groupId}:{maven-artifactId}:{maven-version}
+----
+
+
+If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
+`vertx-jgroups-{maven-version}`.jar` should be in the `lib` directory of the Vert.x installation.
+
+If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
+Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+
+You can also specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options
+when you are creating your Vert.x instance, for example:
+
+[source,ruby]
+----
+require 'vertx/vertx'
+mgr = Java::IoVertxJavaSpiClusterImplJgroups::JGroupsClusterManager.new()
+options = {
+  'clusterManager' => mgr
+}
+Vertx::Vertx.clustered_vertx(options) { |res_err,res|
+  if (res_err == nil)
+    vertx = res
+  else
+    # failed!
+  end
+}
+
+----
+
+== Configuring this cluster manager
+
+Usually the cluster manager is configured by a file:
+
+.default-jgroups.xml
+[source,xml]
+----
+include::../../resources/default-jgroups.xml[]
+----
+
+This file is packaged in the JGroup cluster Manager jar file.
+
+If you want to override this configuration you can provide a file called `jgroups.xml` on your classpath and this
+will be used instead.
+
+The xml file is a JGroups configuration file and is described in detail in the documentation on the JGroups
+web-site.
+
+JGroups supports several different transports including multicast and TCP. The default configuration uses
+multicast so you must have multicast enabled on your network for this to work.
+
+For full documentation on how to configure the transport differently or use a different transport please consult the
+JGroups documentation.
+
+== Trouble shooting clustering
+
+If the default multicast configuration is not working here are some common causes:
+
+=== Multicast not enabled on the machine.
+
+When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
+the routing table otherwise, the default route will be used
+
+Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+
+MacOS example:
+
+----
+# Adds a multicast route for 224.0.0.1-231.255.255.254
+sudo route add -net 224.0.0.0/5 127.0.0.1
+
+# Adds a multicast route for 232.0.0.1-239.255.255.254
+sudo route add -net 232.0.0.0/5 192.168.1.3
+----
+
+Please google for more information.
+
+
+=== Using IPv6 without a correctly configured routing table
+
+Running in IPv6 without a correctly configured IPv6 routing table
+
+By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
+Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`). More details about this
+are available on https://developer.jboss.org/wiki/IPv6.
+
+
+=== Using wrong network interface
+
+If you have more than one network interface on your machine (and this can also be the case if you are running
+VPN software on your machine), then JGroups may be using the wrong one.
+
+Java parameter `jgroups.bind_addr` determines the network interface to bind to, e.g. `jgroups.bind_addr=192.168.1.5`.
+
+The following values are also recognized:
+
+* `global`: picks a global IP address if available. If not, falls back to a `site-local` IP address
+* `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address
+range.
+* `link_local`: picks a link-local IP address, from +169.254.1.0+ through +169.254.254.255+.
+* `non_loopback`: picks _any_ non loopback address.
+* `loopback`: picks a loopback address, e.g. +127.0.0.1+.
+* `match-interface`: picks an address which matches a pattern against the interface name,
+e.g. +match-interface:eth.\*+
+* `match-host`: picks an address which matches a pattern against the host name,
+e.g. +match-host:linux.\*+
+* `match-address`: picks an address which matches a pattern against the host address,
+e.g. +match-address:192.168.\*+
+
+When running Vert.x is in clustered mode, you should also make sure that Vert.x knows about the correct interface.
+When running at the command line this is done by specifying the `cluster-host` option:
+
+----
+vertx run myverticle.js -cluster -cluster-host your-ip-address
+----
+
+Where `your-ip-address` is the same IP address you specified in the JGroups configuration.
+
+If using Vert.x programmatically you can specify this using `link:../../apidocs/io/vertx/core/VertxOptions.html#setClusterHost-java.lang.String-[setClusterHost]`.
+
+
+=== Using a VPN
+
+This is a variation of the above case. VPN software often works by creating a virtual network interface which often
+doesn't support multicast. If you have a VPN running and you do not specify the correct interface to use in both the
+jgroups configuration and to Vert.x then the VPN interface may be chosen instead of the correct interface.
+
+So, if you have a VPN running you may have to configure both the JGroups and Vert.x to use the correct interface as
+described in the previous section.
+
+=== When multicast is not available
+
+In some cases you may not be able to use multicast as it might not be available in your environment. In that case
+you should configure another transport, e.g. TCP  to use TCP sockets, or AWS when running on Amazon EC2.
+
+For more information on available JGroups transports and how to configure them please consult the JGroups
+documentation.
+
+=== Enabling logging
+
+When trouble-shooting clustering issues with JGroups it's often useful to get some logging output from JGroups
+to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+configuration file. Inside it set:
+
+----
+org.jgroups.level=INFO
+----
+
+and also
+
+----
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.FileHandler.level=INFO
+----

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -1,0 +1,24 @@
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.java.spi.cluster.impl.jgroups.JGroupsClusterManager;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class Examples {
+
+  public void example1() {
+    ClusterManager mgr = new JGroupsClusterManager();
+    VertxOptions options = new VertxOptions().setClusterManager(mgr);
+    Vertx.clusteredVertx(options, res -> {
+      if (res.succeeded()) {
+        Vertx vertx = res.result();
+      } else {
+        // failed!
+      }
+    });
+  }
+}

--- a/src/main/java/examples/package-info.java
+++ b/src/main/java/examples/package-info.java
@@ -1,0 +1,4 @@
+@Source
+package examples;
+
+import io.vertx.docgen.Source;

--- a/src/main/java/io/vertx/java/spi/cluster/impl/jgroups/package-info.java
+++ b/src/main/java/io/vertx/java/spi/cluster/impl/jgroups/package-info.java
@@ -1,0 +1,184 @@
+/**
+ * = JGroups Cluster Manager
+ * 
+ * This is a cluster manager implementation for Vert.x that uses http://www.jgroups.org[JGroups].
+ * 
+ * In Vert.x a cluster manager is used for various functions including:
+ * 
+ * * Discovery and group membership of Vert.x nodes in a cluster
+ * * Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus
+ * addresses)
+ * * Distributed Map support
+ * * Distributed Locks
+ * * Distributed Counters
+ * 
+ * Cluster managers *do not* handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
+ * 
+ * == Using this cluster manager
+ *
+ * To use the the cluster manager, add the following dependency to the _dependencies_ section of your build
+ * descriptor:
+ *
+ * * Maven (in your `pom.xml`):
+ *
+ * [source,xml,subs="+attributes"]
+ * ----
+ * <dependency>
+ *   <groupId>{maven-groupId}</groupId>
+ *   <artifactId>{maven-artifactId}</artifactId>
+ *   <version>{maven-version}</version>
+ * </dependency>
+ * ----
+ *
+ * * Gradle (in your `build.gradle` file):
+ *
+ * [source,groovy,subs="+attributes"]
+ * ----
+ * compile {maven-groupId}:{maven-artifactId}:{maven-version}
+ * ----
+ *
+ * 
+ * If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
+ * `vertx-jgroups-{maven-version}.jar` should be in the `lib` directory of the Vert.x installation.
+ *
+ * If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.
+ * Please make sure you don't have any other cluster managers on your classpath or Vert.x might choose the wrong one.
+ * 
+ * You can also specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options
+ * when you are creating your Vert.x instance, for example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#example1()}
+ * ----
+ * 
+ * == Configuring this cluster manager
+ * 
+ * Usually the cluster manager is configured by a file:
+ *
+ * .default-jgroups.xml
+ * [source,xml]
+ * ----
+ * include::../../resources/default-jgroups.xml[]
+ * ----
+ *
+ * This file is packaged in the JGroup cluster Manager jar file.
+ * 
+ * If you want to override this configuration you can provide a file called `jgroups.xml` on your classpath and this
+ * will be used instead.
+ * 
+ * The xml file is a JGroups configuration file and is described in detail in the documentation on the JGroups
+ * web-site.
+ * 
+ * JGroups supports several different transports including multicast and TCP. The default configuration uses
+ * multicast so you must have multicast enabled on your network for this to work.
+ * 
+ * For full documentation on how to configure the transport differently or use a different transport please consult the
+ * JGroups documentation.
+ * 
+ * == Trouble shooting clustering
+ * 
+ * If the default multicast configuration is not working here are some common causes:
+ * 
+ * === Multicast not enabled on the machine.
+ * 
+ * When using `UDP`, IP multicasting is required, on some systems, multicast route(s) need to be added to
+ * the routing table otherwise, the default route will be used
+ * 
+ * Note that some systems don't consult the routing table for IP multicast routing, only for unicast routing
+ * 
+ * MacOS example:
+ * 
+ * ----
+ * # Adds a multicast route for 224.0.0.1-231.255.255.254
+ * sudo route add -net 224.0.0.0/5 127.0.0.1
+ * 
+ * # Adds a multicast route for 232.0.0.1-239.255.255.254
+ * sudo route add -net 232.0.0.0/5 192.168.1.3
+ * ----
+ * 
+ * Please google for more information.
+ * 
+ * 
+ * === Using IPv6 without a correctly configured routing table
+ * 
+ * Running in IPv6 without a correctly configured IPv6 routing table
+ * 
+ * By default, the JVM uses IPv6, but the routing table is not configured correctly, or the config uses IPv4
+ * Solution: look at IPv6 routing or force use of IPv4 (`-Djava.net.preferIPv4Stack=true`). More details about this
+ * are available on https://developer.jboss.org/wiki/IPv6.
+ * 
+ * 
+ * === Using wrong network interface
+ * 
+ * If you have more than one network interface on your machine (and this can also be the case if you are running
+ * VPN software on your machine), then JGroups may be using the wrong one.
+ * 
+ * Java parameter `jgroups.bind_addr` determines the network interface to bind to, e.g. `jgroups.bind_addr=192.168.1.5`.
+ * 
+ * The following values are also recognized:
+ * 
+ * * `global`: picks a global IP address if available. If not, falls back to a `site-local` IP address
+ * * `site_local`: picks a site local (non routable) IP address, e.g. from the +192.168.0.0+ or +10.0.0.0+ address
+ * range.
+ * * `link_local`: picks a link-local IP address, from +169.254.1.0+ through +169.254.254.255+.
+ * * `non_loopback`: picks _any_ non loopback address.
+ * * `loopback`: picks a loopback address, e.g. +127.0.0.1+.
+ * * `match-interface`: picks an address which matches a pattern against the interface name,
+ * e.g. +match-interface:eth.\*+
+ * * `match-host`: picks an address which matches a pattern against the host name,
+ * e.g. +match-host:linux.\*+
+ * * `match-address`: picks an address which matches a pattern against the host address,
+ * e.g. +match-address:192.168.\*+
+ * 
+ * When running Vert.x is in clustered mode, you should also make sure that Vert.x knows about the correct interface.
+ * When running at the command line this is done by specifying the `cluster-host` option:
+ * 
+ * ----
+ * vertx run myverticle.js -cluster -cluster-host your-ip-address
+ * ----
+ * 
+ * Where `your-ip-address` is the same IP address you specified in the JGroups configuration.
+ * 
+ * If using Vert.x programmatically you can specify this using `link:../../apidocs/io/vertx/core/VertxOptions.html#setClusterHost-java.lang.String-[setClusterHost]`.
+ * 
+ * 
+ * === Using a VPN
+ * 
+ * This is a variation of the above case. VPN software often works by creating a virtual network interface which often
+ * doesn't support multicast. If you have a VPN running and you do not specify the correct interface to use in both the
+ * jgroups configuration and to Vert.x then the VPN interface may be chosen instead of the correct interface.
+ * 
+ * So, if you have a VPN running you may have to configure both the JGroups and Vert.x to use the correct interface as
+ * described in the previous section.
+ * 
+ * === When multicast is not available
+ * 
+ * In some cases you may not be able to use multicast as it might not be available in your environment. In that case
+ * you should configure another transport, e.g. TCP  to use TCP sockets, or AWS when running on Amazon EC2.
+ * 
+ * For more information on available JGroups transports and how to configure them please consult the JGroups
+ * documentation.
+ * 
+ * === Enabling logging
+ * 
+ * When trouble-shooting clustering issues with JGroups it's often useful to get some logging output from JGroups
+ * to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
+ * called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+ * configuration file. Inside it set:
+ * 
+ * ----
+ * org.jgroups.level=INFO
+ * ----
+ * 
+ * and also
+ * 
+ * ----
+ * java.util.logging.ConsoleHandler.level=INFO
+ * java.util.logging.FileHandler.level=INFO
+ * ----
+ */
+@Document(fileName = "index.adoc")
+package io.vertx.java.spi.cluster.impl.jgroups;
+
+import io.vertx.docgen.Document;


### PR DESCRIPTION
I've refactored the project to use the documentation generation we use in vert.x. It generates a manual per supported language and the examples are transcoded to all languages. 

I've also updated the documentation to use the variables we used in other project. 
