### PR TITLE
Added synchronized modifier to fix ArrayIndexOutOfBounds Exception in…

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/jgroups/impl/domain/ChoosableArrayListImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/jgroups/impl/domain/ChoosableArrayListImpl.java
@@ -60,7 +60,7 @@ public class ChoosableArrayListImpl<T> implements ChoosableArrayList<T> {
   }
 
   @Override
-  public T choose() {
+  public synchronized T choose() {
     if (roundRobinIndex >= values.size()) {
       roundRobinIndex = 0;
     }


### PR DESCRIPTION
… highly concurrent scenarios.

With fast cores and multiple event loops and high load on the eventbus, the volatile modifier was not enough in the ChoosableArrayListImpl: a parallel thread can no longer increment the counter between the overflow check _(if (roundRobinIndex >= values.size())_ and the actual _List.get(roundRobinIndex++)_
