### PR TITLE
Upgrade to JGroups 3.6.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <stack.version>3.4.0-SNAPSHOT</stack.version>
-    <jgroups.version>3.6.8.Final</jgroups.version>
+    <jgroups.version>3.6.10.Final</jgroups.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.9.5</mockito.version>
 


### PR DESCRIPTION
In JGroups version 3.6.10 several bugs were fixed, some are quite critical.

No code changes needed.
