### PR TITLE
More cluster tests

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -25,7 +25,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-jgroups</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,12 +33,12 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-jgroups:3.3.3'
+compile 'io.vertx:vertx-jgroups:3.4.0-SNAPSHOT'
 ----
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-3.3.3.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
+`vertx-jgroups-3.4.0-SNAPSHOT.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
 also add the `jgroups` jar too (`org.jgroups:jgroups:jar`).
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -25,7 +25,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-jgroups</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,12 +33,12 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-jgroups:3.3.3'
+compile 'io.vertx:vertx-jgroups:3.4.0-SNAPSHOT'
 ----
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-3.3.3.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
+`vertx-jgroups-3.4.0-SNAPSHOT.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
 also add the `jgroups` jar too (`org.jgroups:jgroups:jar`).
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -25,7 +25,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-jgroups</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,12 +33,12 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-jgroups:3.3.3'
+compile 'io.vertx:vertx-jgroups:3.4.0-SNAPSHOT'
 ----
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-3.3.3.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
+`vertx-jgroups-3.4.0-SNAPSHOT.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
 also add the `jgroups` jar too (`org.jgroups:jgroups:jar`).
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -25,7 +25,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-jgroups</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,12 +33,12 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-jgroups:3.3.3'
+compile 'io.vertx:vertx-jgroups:3.4.0-SNAPSHOT'
 ----
 
 
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named
-`vertx-jgroups-3.3.3.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
+`vertx-jgroups-3.4.0-SNAPSHOT.jar` should be in the `lib` directory of the Vert.x installation. Don't forget to
 also add the `jgroups` jar too (`org.jgroups:jgroups:jar`).
 
 If the jar is on your classpath as above then Vert.x will automatically detect this and use it as the cluster manager.

--- a/src/main/java/io/vertx/spi/cluster/jgroups/impl/domain/async/AsyncMapWrapper.java
+++ b/src/main/java/io/vertx/spi/cluster/jgroups/impl/domain/async/AsyncMapWrapper.java
@@ -17,6 +17,7 @@
 package io.vertx.spi.cluster.jgroups.impl.domain.async;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -24,10 +25,9 @@ import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.spi.cluster.jgroups.impl.services.RpcExecutorService;
 import io.vertx.spi.cluster.jgroups.impl.support.LambdaLogger;
 
-import static io.vertx.spi.cluster.jgroups.impl.services.RpcServerObjDelegate.*;
-
-
 import java.util.Map;
+
+import static io.vertx.spi.cluster.jgroups.impl.services.RpcServerObjDelegate.*;
 
 public class AsyncMapWrapper<K, V> implements AsyncMap<K, V>, LambdaLogger {
 
@@ -57,8 +57,7 @@ public class AsyncMapWrapper<K, V> implements AsyncMap<K, V>, LambdaLogger {
 
   @Override
   public void put(K k, V v, long timeout, Handler<AsyncResult<Void>> handler) {
-    logTrace(() -> "put k = [" + k + "], v = [" + v + "], timeout = [" + timeout + "] handler = [" + handler + "]");
-    executorService.remoteExecute(CALL_MAP_PUT.method(name, k, v), timeout, handler);
+    handler.handle(Future.failedFuture(new UnsupportedOperationException()));
   }
 
   @Override
@@ -69,8 +68,7 @@ public class AsyncMapWrapper<K, V> implements AsyncMap<K, V>, LambdaLogger {
 
   @Override
   public void putIfAbsent(K k, V v, long timeout, Handler<AsyncResult<V>> handler) {
-    logTrace(() -> "putIfAbsent k = [" + k + "], v = [" + v + "], timeout = [" + timeout + "] handler = [" + handler + "]");
-    executorService.remoteExecute(CALL_MAP_PUTIFABSENT.method(name, k, v), timeout, handler);
+    handler.handle(Future.failedFuture(new UnsupportedOperationException()));
   }
 
   @Override

--- a/src/test/java/io/vertx/test/core/JGroupsClusterWideMapTest.java
+++ b/src/test/java/io/vertx/test/core/JGroupsClusterWideMapTest.java
@@ -16,10 +16,12 @@
 
 package io.vertx.test.core;
 
-import org.junit.Rule;
-
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.jgroups.JGroupsClusterManager;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
 
 public class JGroupsClusterWideMapTest extends ClusterWideMapTestDifferentNodes {
 
@@ -29,5 +31,29 @@ public class JGroupsClusterWideMapTest extends ClusterWideMapTestDifferentNodes 
   @Override
   protected ClusterManager getClusterManager() {
     return new JGroupsClusterManager();
+  }
+
+  @Override
+  @Test
+  public void testMapPutTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.put("k", "v", 13, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Override
+  @Test
+  public void testMapPutIfAbsentTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.putIfAbsent("k", "v", 13, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
   }
 }

--- a/src/test/java/io/vertx/test/core/JGroupsClusteredAsynchronousLockTest.java
+++ b/src/test/java/io/vertx/test/core/JGroupsClusteredAsynchronousLockTest.java
@@ -16,10 +16,10 @@
 
 package io.vertx.test.core;
 
-import org.junit.Rule;
-
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.jgroups.JGroupsClusterManager;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class JGroupsClusteredAsynchronousLockTest extends ClusteredAsynchronousLockTest {
 
@@ -29,5 +29,17 @@ public class JGroupsClusteredAsynchronousLockTest extends ClusteredAsynchronousL
   @Override
   protected ClusterManager getClusterManager() {
     return new JGroupsClusterManager();
+  }
+
+  @Override
+  @Test
+  public void testLockReleasedForClosedNode() throws Exception {
+    super.testLockReleasedForClosedNode();
+  }
+
+  @Override
+  @Test
+  public void testLockReleasedForKilledNode() throws Exception {
+    super.testLockReleasedForKilledNode();
   }
 }


### PR DESCRIPTION
This follows up on eclipse/vert.x#1609

We need to update the CM implementation because currently put/putIfAbsent with ttl variants are not supported.
It was assumed that the timeout parameter was for the cache operation but it is actually the expected cache entry lifespan.

Also, enabled the new tests for locks (lock released on dead node)
